### PR TITLE
Add adaptive charge calibration and improve desktop reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,21 @@ debug.prev.log
 *.delta
 RELEASES
 AGENTS.md
+
+# AI Agent Instructions
+.ai-agent-rules.md
+.ai-task-template.md
+.github/copilot-instructions.md
+.cursorrules
+.clinerules
+.windsurfrules
+
+# AI Agent Files
+.ai-*
+.llm-logs/
+.ai-cache/
+
+# Keep only CI workflows tracked under .github
+.github/*
+!.github/workflows/
+!.github/workflows/**

--- a/src/GBM.Core/Models/BatteryEstimate.cs
+++ b/src/GBM.Core/Models/BatteryEstimate.cs
@@ -26,3 +26,7 @@ public record LearnedRates(
     double? ChargeRate,
     int DischargeSessionCount,
     int ChargeSessionCount);
+
+public record ChargeCalibration(
+    double OvershootPercent,
+    int ObservationCount);

--- a/src/GBM.Core/Models/ChargeData.cs
+++ b/src/GBM.Core/Models/ChargeData.cs
@@ -19,6 +19,11 @@ public class DeviceChargeData
     public double? LearnedChargeRate { get; set; }
     public int DischargeSessionCount { get; set; }
     public int ChargeSessionCount { get; set; }
+
+    // Learned charging overshoot correction, observed after unplug events.
+    // Example: estimated 100% while wired, first stable wireless sample is 86% => 14% overshoot.
+    public double? LearnedChargeOvershootPercent { get; set; }
+    public int ChargeOvershootObservationCount { get; set; }
 }
 
 public class BatterySample

--- a/src/GBM.Core/Services/BatteryEstimationService.cs
+++ b/src/GBM.Core/Services/BatteryEstimationService.cs
@@ -28,6 +28,9 @@ public class BatteryEstimationService : IBatteryEstimationService
     private const int MinLevelDeltaForOngoingDischargeLearning = 1;
     private const int MinLevelDeltaForOngoingChargeLearning = 2;
     private static readonly TimeSpan MinSpanForLowDeltaEstimate = TimeSpan.FromHours(2);
+    private static readonly TimeSpan MaxChargeOvershootObservationAge = TimeSpan.FromMinutes(10);
+    private const double MinChargeOvershootLearnPercent = 2.0;
+    private const double MaxChargeOvershootLearnPercent = 40.0;
 
     // Default rates for first-ever use (before any learning).
     // These provide an immediate estimate so "Calculating..." never lingers.
@@ -203,6 +206,85 @@ public class BatteryEstimationService : IBatteryEstimationService
                 state.HistoricalChargeRate,
                 state.DischargeSessionCount,
                 state.ChargeSessionCount);
+        }
+    }
+
+    public void SetChargeCalibration(string deviceKey, double? overshootPercent, int observationCount)
+    {
+        lock (_lock)
+        {
+            if (!_states.TryGetValue(deviceKey, out var state))
+            {
+                state = new DeviceEstimationState();
+                _states[deviceKey] = state;
+            }
+
+            if (!overshootPercent.HasValue || overshootPercent.Value <= 0 || observationCount <= 0)
+            {
+                state.ChargeOvershootPercent = null;
+                state.ChargeOvershootObservationCount = 0;
+                return;
+            }
+
+            state.ChargeOvershootPercent = Math.Clamp(
+                overshootPercent.Value,
+                MinChargeOvershootLearnPercent,
+                MaxChargeOvershootLearnPercent);
+            state.ChargeOvershootObservationCount = observationCount;
+        }
+    }
+
+    public void ObserveChargeDropAfterUnplug(string deviceKey, int anchorLevel, int measuredLevel, TimeSpan elapsed)
+    {
+        lock (_lock)
+        {
+            if (!_states.TryGetValue(deviceKey, out var state))
+            {
+                state = new DeviceEstimationState();
+                _states[deviceKey] = state;
+            }
+
+            if (elapsed <= TimeSpan.Zero || elapsed > MaxChargeOvershootObservationAge)
+                return;
+
+            if (anchorLevel <= 0 || anchorLevel > 100 || measuredLevel < 0 || measuredLevel > 100)
+                return;
+
+            int drop = anchorLevel - measuredLevel;
+            if (drop < MinChargeOvershootLearnPercent || drop > MaxChargeOvershootLearnPercent)
+            {
+                return;
+            }
+
+            double? overshoot = state.ChargeOvershootPercent;
+            int count = state.ChargeOvershootObservationCount;
+            BlendCalibration(ref overshoot, ref count, drop);
+
+            state.ChargeOvershootPercent = overshoot;
+            state.ChargeOvershootObservationCount = count;
+
+            _logger.LogInformation(
+                "Learned charge overshoot for {Key}: observed={Observed:F1}%, historical={Historical:F1}% ({Observations} observations)",
+                deviceKey,
+                (double)drop,
+                state.ChargeOvershootPercent ?? 0,
+                state.ChargeOvershootObservationCount);
+        }
+    }
+
+    public ChargeCalibration? GetChargeCalibration(string deviceKey)
+    {
+        lock (_lock)
+        {
+            if (!_states.TryGetValue(deviceKey, out var state))
+                return null;
+
+            if (!state.ChargeOvershootPercent.HasValue || state.ChargeOvershootObservationCount <= 0)
+                return null;
+
+            return new ChargeCalibration(
+                state.ChargeOvershootPercent.Value,
+                state.ChargeOvershootObservationCount);
         }
     }
 
@@ -382,6 +464,21 @@ public class BatteryEstimationService : IBatteryEstimationService
             int cappedCount = Math.Min(sessionCount, MaxHistoricalSessions);
             historicalRate = (historicalRate.Value * cappedCount + sessionRate) / (cappedCount + 1);
             sessionCount++;
+        }
+    }
+
+    private static void BlendCalibration(ref double? historicalOvershoot, ref int observationCount, double observedOvershoot)
+    {
+        if (!historicalOvershoot.HasValue || observationCount <= 0)
+        {
+            historicalOvershoot = observedOvershoot;
+            observationCount = 1;
+        }
+        else
+        {
+            int cappedCount = Math.Min(observationCount, MaxHistoricalSessions);
+            historicalOvershoot = (historicalOvershoot.Value * cappedCount + observedOvershoot) / (cappedCount + 1);
+            observationCount++;
         }
     }
 
@@ -669,6 +766,8 @@ public class BatteryEstimationService : IBatteryEstimationService
         public double? HistoricalChargeRate { get; set; }
         public int DischargeSessionCount { get; set; }
         public int ChargeSessionCount { get; set; }
+        public double? ChargeOvershootPercent { get; set; }
+        public int ChargeOvershootObservationCount { get; set; }
 
         // EWMA smoothed instantaneous discharge/charge rate (per sample pair)
         public double? SmoothedRate { get; set; }

--- a/src/GBM.Core/Services/BatteryMonitorService.cs
+++ b/src/GBM.Core/Services/BatteryMonitorService.cs
@@ -59,6 +59,14 @@ public class BatteryMonitorService : IBatteryMonitorService, IDisposable
     // Skip polling during this window to avoid accumulating false failures.
     private DateTime? _cableDisconnectTime;
     private static readonly TimeSpan PostDisconnectSettlingDelay = TimeSpan.FromSeconds(5);
+    private DateTime? _pendingUnplugCalibrationUtc;
+    private int? _pendingUnplugCalibrationAnchorLevel;
+    private bool _awaitingUnplugCalibrationSample;
+    private static readonly TimeSpan MaxUnplugCalibrationWindow = TimeSpan.FromMinutes(10);
+    private const int MinUnplugCalibrationDrop = 5;
+    private const int MaxUnplugCalibrationDrop = 40;
+    private const int MinLevelForUnplugCalibration = 20;
+    private const int ChargeCalibrationFullConfidenceObservations = 6;
 
     // Li-ion charge curve constants (typical for 500-700mAh gaming mouse cells)
     private const double CcRatePerHour = 60.0;   // CC phase (<80%): 60%/hr
@@ -215,6 +223,9 @@ public class BatteryMonitorService : IBatteryMonitorService, IDisposable
         _chargeStartTime = null;
         _chargeStartLevel = 0;
         _cableDisconnectTime = null;
+        _pendingUnplugCalibrationUtc = null;
+        _pendingUnplugCalibrationAnchorLevel = null;
+        _awaitingUnplugCalibrationSample = false;
         _probeExhausted = false;
         _exhaustedProbeDebounce = TimeSpan.FromSeconds(60);
     }
@@ -316,6 +327,8 @@ public class BatteryMonitorService : IBatteryMonitorService, IDisposable
 
                 if (wiredPresent && !_lastWiredPresent)
                 {
+                    ClearPendingUnplugCalibration();
+
                     // Cable just plugged in - record charge start for estimation.
                     // Do NOT reset _activeProfile or trigger reconnect: the CandidateF
                     // poll on PID=0x824D remains valid while the cable is in.
@@ -328,6 +341,18 @@ public class BatteryMonitorService : IBatteryMonitorService, IDisposable
                 }
                 else if (!wiredPresent)
                 {
+                    int anchorLevel = CurrentState.Level > 0 ? CurrentState.Level : _lastPositiveLevel;
+                    if (anchorLevel >= MinLevelForUnplugCalibration)
+                    {
+                        _pendingUnplugCalibrationAnchorLevel = anchorLevel;
+                        _pendingUnplugCalibrationUtc = DateTime.UtcNow;
+                        _awaitingUnplugCalibrationSample = true;
+                    }
+                    else
+                    {
+                        ClearPendingUnplugCalibration();
+                    }
+
                     // Cable unplugged - clear charge tracking.
                     // The device needs a few seconds to settle back into wireless mode
                     // before it will respond to GetFeature again. Record the disconnect
@@ -500,8 +525,38 @@ public class BatteryMonitorService : IBatteryMonitorService, IDisposable
             remaining -= step;
         }
 
+        level = ApplyChargeCalibrationCorrection(level);
+
         int result = Math.Min((int)Math.Round(level), MaxEstimatedLevel);
         return Math.Max(result, _chargeStartLevel); // Never go below start level
+    }
+
+    private double ApplyChargeCalibrationCorrection(double estimatedLevel)
+    {
+        if (_activeProfile == null)
+            return estimatedLevel;
+
+        if (_chargeStartLevel <= 0 || estimatedLevel <= _chargeStartLevel)
+            return estimatedLevel;
+
+        string deviceKey = _activeProfile.CompositeKey ?? _activeProfile.ModelName;
+        var calibration = _estimationService.GetChargeCalibration(deviceKey);
+        if (calibration == null || calibration.OvershootPercent <= 0)
+            return estimatedLevel;
+
+        double span = Math.Max(1.0, 100.0 - _chargeStartLevel);
+        double progress = Math.Clamp((estimatedLevel - _chargeStartLevel) / span, 0.0, 1.0);
+        if (progress <= 0)
+            return estimatedLevel;
+
+        double confidence = Math.Clamp(
+            calibration.ObservationCount / (double)ChargeCalibrationFullConfidenceObservations,
+            0.25,
+            1.0);
+        double correction = calibration.OvershootPercent * progress * confidence;
+        double corrected = estimatedLevel - correction;
+
+        return Math.Max(corrected, _chargeStartLevel);
     }
 
     private bool TryReadRealtimeChargingLevel(out int level)
@@ -740,6 +795,9 @@ public class BatteryMonitorService : IBatteryMonitorService, IDisposable
         {
             _estimationService.AddSample(deviceKey, displayLevel, isCharging);
         }
+
+        TryLearnFromPostUnplugObservation(deviceKey, displayLevel, isCharging, shouldSkipEstimationSample);
+
         var estimate = _estimationService.GetEstimate(deviceKey);
         UpdateEstimate(estimate);
         _successfulReadsSinceLearnedPersist++;
@@ -757,6 +815,42 @@ public class BatteryMonitorService : IBatteryMonitorService, IDisposable
 
         // Process notifications
         _notificationService.ProcessBatteryUpdate(newState, previousState, _settingsService.Current);
+    }
+
+    private void TryLearnFromPostUnplugObservation(string deviceKey, int level, bool isCharging, bool skipEstimationSample)
+    {
+        if (!_awaitingUnplugCalibrationSample)
+            return;
+
+        if (isCharging || skipEstimationSample)
+            return;
+
+        DateTime? unplugTime = _pendingUnplugCalibrationUtc;
+        int? anchorLevel = _pendingUnplugCalibrationAnchorLevel;
+        ClearPendingUnplugCalibration();
+
+        if (!unplugTime.HasValue || !anchorLevel.HasValue)
+            return;
+
+        TimeSpan elapsed = DateTime.UtcNow - unplugTime.Value;
+        if (elapsed <= TimeSpan.Zero || elapsed > MaxUnplugCalibrationWindow)
+            return;
+
+        if (anchorLevel.Value < MinLevelForUnplugCalibration)
+            return;
+
+        int drop = anchorLevel.Value - level;
+        if (drop < MinUnplugCalibrationDrop || drop > MaxUnplugCalibrationDrop)
+            return;
+
+        _estimationService.ObserveChargeDropAfterUnplug(deviceKey, anchorLevel.Value, level, elapsed);
+    }
+
+    private void ClearPendingUnplugCalibration()
+    {
+        _pendingUnplugCalibrationUtc = null;
+        _pendingUnplugCalibrationAnchorLevel = null;
+        _awaitingUnplugCalibrationSample = false;
     }
 
     private void ProcessFailedRead()
@@ -1029,6 +1123,14 @@ public class BatteryMonitorService : IBatteryMonitorService, IDisposable
                         data.LearnedDischargeRate, data.LearnedChargeRate,
                         data.DischargeSessionCount, data.ChargeSessionCount);
                 }
+
+                if (data.LearnedChargeOvershootPercent.HasValue && data.ChargeOvershootObservationCount > 0)
+                {
+                    _estimationService.SetChargeCalibration(
+                        key,
+                        data.LearnedChargeOvershootPercent,
+                        data.ChargeOvershootObservationCount);
+                }
             }
         }
         catch (Exception ex)
@@ -1108,11 +1210,25 @@ public class BatteryMonitorService : IBatteryMonitorService, IDisposable
                 _storageService.UpdateLearnedRates(deviceKey,
                     learned.DischargeRate, learned.ChargeRate,
                     learned.DischargeSessionCount, learned.ChargeSessionCount, force);
+            }
+
+            var calibration = _estimationService.GetChargeCalibration(deviceKey);
+            if (calibration != null)
+            {
+                _storageService.UpdateChargeCalibration(
+                    deviceKey,
+                    calibration.OvershootPercent,
+                    calibration.ObservationCount,
+                    force);
+            }
+
+            if (learned != null || calibration != null)
+            {
                 _lastLearnedRatesPersistUtc = DateTime.UtcNow;
                 _successfulReadsSinceLearnedPersist = 0;
                 if (force)
                 {
-                    _logger.LogDebug("Persisted learned rates for {Key} (forced)", deviceKey);
+                    _logger.LogDebug("Persisted learned data for {Key} (forced)", deviceKey);
                 }
             }
         }

--- a/src/GBM.Core/Services/IBatteryEstimationService.cs
+++ b/src/GBM.Core/Services/IBatteryEstimationService.cs
@@ -10,4 +10,7 @@ public interface IBatteryEstimationService
     void SetHistoricalRates(string deviceKey, double? dischargeRate, double? chargeRate,
                             int dischargeSessionCount, int chargeSessionCount);
     LearnedRates? GetLearnedRates(string deviceKey);
+    void SetChargeCalibration(string deviceKey, double? overshootPercent, int observationCount);
+    void ObserveChargeDropAfterUnplug(string deviceKey, int anchorLevel, int measuredLevel, TimeSpan elapsed);
+    ChargeCalibration? GetChargeCalibration(string deviceKey);
 }

--- a/src/GBM.Core/Services/IStorageService.cs
+++ b/src/GBM.Core/Services/IStorageService.cs
@@ -14,4 +14,6 @@ public interface IStorageService
     void UpdateChargeInfo(string deviceKey, int level, DateTime? chargeTime);
     void UpdateLearnedRates(string deviceKey, double? dischargeRate, double? chargeRate,
                             int dischargeSessions, int chargeSessions, bool forceSave = false);
+    void UpdateChargeCalibration(string deviceKey, double? overshootPercent,
+                                 int observationCount, bool forceSave = false);
 }

--- a/src/GBM.Core/Services/StorageService.cs
+++ b/src/GBM.Core/Services/StorageService.cs
@@ -210,6 +210,29 @@ public class StorageService : IStorageService
         }
     }
 
+    public void UpdateChargeCalibration(string deviceKey, double? overshootPercent,
+                                        int observationCount, bool forceSave = false)
+    {
+        lock (_chargeDataLock)
+        {
+            try
+            {
+                var data = LoadChargeDataInternal();
+                var deviceData = GetOrCreateDeviceData(data, deviceKey);
+
+                deviceData.LearnedChargeOvershootPercent = overshootPercent;
+                deviceData.ChargeOvershootObservationCount = observationCount;
+
+                _cachedChargeData = data;
+                SaveChargeDataInternal(data, force: forceSave);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to update charge calibration for device {Key}", deviceKey);
+            }
+        }
+    }
+
     private ChargeData LoadChargeDataInternal()
     {
         if (_cachedChargeData != null)

--- a/src/GBM.Desktop/App.axaml.cs
+++ b/src/GBM.Desktop/App.axaml.cs
@@ -46,7 +46,6 @@ public partial class App : Application
 
             // Apply theme from settings
             var settingsService = _serviceProvider.GetRequiredService<ISettingsService>();
-            settingsService.Load();
             ApplyTheme(settingsService.Current.Theme);
             settingsService.SettingsChanged += s => ApplyTheme(s.Theme);
 

--- a/src/GBM.Desktop/Services/WindowsToastService.cs
+++ b/src/GBM.Desktop/Services/WindowsToastService.cs
@@ -1,6 +1,5 @@
 using GBM.Core.Models;
 using Microsoft.Extensions.Logging;
-using System.Runtime.InteropServices;
 
 namespace GBM.Desktop.Services;
 
@@ -55,7 +54,7 @@ public class WindowsToastService : IDisposable
             // Display via direct WinRT API call
             _ = Task.Run(() => ShowToastViaWinRT(title, bodyText, iconUri, audioSrc, type));
 
-            _logger.LogInformation("[TOAST] Delivered [{Type}]: {Title}", type, title);
+            _logger.LogInformation("[TOAST] Queued [{Type}]: {Title}", type, title);
         }
         catch (Exception ex)
         {
@@ -81,27 +80,16 @@ public class WindowsToastService : IDisposable
 
             string toastXml = $@"<toast duration=""short""><visual><binding template=""ToastGeneric"">{logoXml}<text hint-maxLines=""1"">{EscapeXml(title)}</text><text>{EscapeXml(message)}</text><text placement=""attribution"">Glorious Battery Monitor</text></binding></visual><audio src=""{audioSrc}"" loop=""false""/></toast>";
 
-            // Use direct WinRT API with proper COM object cleanup
+            // Use direct WinRT API. CsWinRT projections are not always COM objects,
+            // so explicit ReleaseComObject calls can throw on newer runtimes.
             var doc = new Windows.Data.Xml.Dom.XmlDocument();
-            try
+            doc.LoadXml(toastXml);
+            var toast = new Windows.UI.Notifications.ToastNotification(doc)
             {
-                doc.LoadXml(toastXml);
-                var toast = new Windows.UI.Notifications.ToastNotification(doc);
-                try
-                {
-                    toast.Tag = "battery";
-                    toast.Group = "battery";
-                    _toastNotifier.Show(toast);
-                }
-                finally
-                {
-                    Marshal.ReleaseComObject(toast);
-                }
-            }
-            finally
-            {
-                Marshal.ReleaseComObject(doc);
-            }
+                Tag = "battery",
+                Group = "battery"
+            };
+            _toastNotifier.Show(toast);
 
             _logger.LogDebug("[TOAST] WinRT toast displayed successfully");
         }
@@ -187,8 +175,6 @@ public class WindowsToastService : IDisposable
 
         if (_toastNotifier != null)
         {
-            try { Marshal.ReleaseComObject(_toastNotifier); }
-            catch { }
             _toastNotifier = null;
         }
     }

--- a/src/GBM.Tests/Services/BatteryEstimationTests.cs
+++ b/src/GBM.Tests/Services/BatteryEstimationTests.cs
@@ -404,4 +404,39 @@ public class BatteryEstimationTests
         learned!.DischargeRate.Should().BeApproximately(1.0, 0.01);
         learned.DischargeSessionCount.Should().Be(5);
     }
+
+    [Fact]
+    public void ObserveChargeDropAfterUnplug_LearnsChargeOvershootCalibration()
+    {
+        _service.ObserveChargeDropAfterUnplug("calibration", anchorLevel: 100, measuredLevel: 86,
+            elapsed: TimeSpan.FromMinutes(1));
+
+        var calibration = _service.GetChargeCalibration("calibration");
+        calibration.Should().NotBeNull();
+        calibration!.OvershootPercent.Should().BeApproximately(14.0, 0.01);
+        calibration.ObservationCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void ObserveChargeDropAfterUnplug_BlendsAcrossObservations()
+    {
+        _service.ObserveChargeDropAfterUnplug("calibration", anchorLevel: 100, measuredLevel: 90,
+            elapsed: TimeSpan.FromMinutes(1));
+        _service.ObserveChargeDropAfterUnplug("calibration", anchorLevel: 98, measuredLevel: 86,
+            elapsed: TimeSpan.FromMinutes(2));
+
+        var calibration = _service.GetChargeCalibration("calibration");
+        calibration.Should().NotBeNull();
+        calibration!.OvershootPercent.Should().BeApproximately(11.0, 0.01);
+        calibration.ObservationCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void ObserveChargeDropAfterUnplug_IgnoresStaleObservation()
+    {
+        _service.ObserveChargeDropAfterUnplug("stale", anchorLevel: 100, measuredLevel: 85,
+            elapsed: TimeSpan.FromMinutes(20));
+
+        _service.GetChargeCalibration("stale").Should().BeNull();
+    }
 }

--- a/src/GBM.Tests/Services/BatteryMonitorReliabilityTests.cs
+++ b/src/GBM.Tests/Services/BatteryMonitorReliabilityTests.cs
@@ -175,6 +175,24 @@ public class BatteryMonitorReliabilityTests
         monitor.CurrentState.IsCharging.Should().BeTrue();
     }
 
+    [Fact]
+    public void ProcessSuccessfulRead_FirstStableReadAfterUnplug_LearnsCalibration()
+    {
+        var monitor = CreateMonitor(out _, out _, out _, out var estimation);
+        var profile = CreateProfile();
+
+        SetPrivateField(monitor, "_activeProfile", profile);
+        SetPrivateField(monitor, "_awaitingUnplugCalibrationSample", true);
+        SetPrivateField(monitor, "_pendingUnplugCalibrationAnchorLevel", 100);
+        SetPrivateField(monitor, "_pendingUnplugCalibrationUtc", DateTime.UtcNow - TimeSpan.FromSeconds(20));
+
+        InvokePrivate(monitor, "ProcessSuccessfulRead", 86, false, false);
+
+        estimation.Verify(
+            e => e.ObserveChargeDropAfterUnplug(profile.CompositeKey, 100, 86, It.IsAny<TimeSpan>()),
+            Times.Once);
+    }
+
     private static BatteryMonitorService CreateMonitor(
         out Mock<IHidDeviceService> hid,
         out Mock<ISettingsService> settings,
@@ -209,6 +227,7 @@ public class BatteryMonitorReliabilityTests
             IsHistorical = true
         });
         estimation.Setup(e => e.GetLearnedRates(It.IsAny<string>())).Returns((LearnedRates?)null);
+        estimation.Setup(e => e.GetChargeCalibration(It.IsAny<string>())).Returns((ChargeCalibration?)null);
 
         return new BatteryMonitorService(
             logger.Object,

--- a/src/GBM.Tests/Services/StorageServiceTests.cs
+++ b/src/GBM.Tests/Services/StorageServiceTests.cs
@@ -71,6 +71,37 @@ public class StorageServiceTests
         }
     }
 
+    [Fact]
+    public void UpdateChargeCalibration_ForceFlagControlsImmediateDiskPersistence()
+    {
+        string appDataPath = CreateTempDirectory();
+        const string deviceKey = "device";
+
+        try
+        {
+            var service = CreateStorageService(appDataPath);
+            service.AddBatterySample(deviceKey, 75, isCharging: true);
+
+            service.UpdateChargeCalibration(deviceKey, 12.0, 2, forceSave: false);
+
+            var reloadedAfterNonForced = CreateStorageService(appDataPath).GetDeviceChargeData(deviceKey);
+            reloadedAfterNonForced.Should().NotBeNull();
+            reloadedAfterNonForced!.LearnedChargeOvershootPercent.Should().BeNull();
+            reloadedAfterNonForced.ChargeOvershootObservationCount.Should().Be(0);
+
+            service.UpdateChargeCalibration(deviceKey, 12.0, 2, forceSave: true);
+
+            var reloadedAfterForced = CreateStorageService(appDataPath).GetDeviceChargeData(deviceKey);
+            reloadedAfterForced.Should().NotBeNull();
+            reloadedAfterForced!.LearnedChargeOvershootPercent.Should().Be(12.0);
+            reloadedAfterForced.ChargeOvershootObservationCount.Should().Be(2);
+        }
+        finally
+        {
+            TryDeleteDirectory(appDataPath);
+        }
+    }
+
     private static StorageService CreateStorageService(string appDataPath)
     {
         var logger = new Mock<ILogger<StorageService>>();


### PR DESCRIPTION
This pull request introduces a system for learning and applying charge overshoot correction to battery level estimates after a device is unplugged from charging. The main goal is to improve the accuracy of battery percentage estimates by observing and compensating for the typical drop seen when switching from wired to wireless power. The implementation includes data model changes, storage updates, and the learning/correction logic in both the estimation and monitoring services.

**Charge Overshoot Learning and Correction**

* Added a new `ChargeCalibration` record and associated fields to track overshoot percent and observation counts in `DeviceChargeData` and internal state (`DeviceEstimationState`). [[1]](diffhunk://#diff-39ed0d72e77b5c8b804026a34bae9d0d12ad0a3f79607f6a5e94e9e3e6359fe4R29-R32) [[2]](diffhunk://#diff-182574abe3889857721fe2d2e2de0eea8b73a076774452dbde330495da655315R22-R26) [[3]](diffhunk://#diff-63d83a42c37f697f23ce41ab734b54ee3b2792b41cb54b96ab41983f1ee53165R769-R770)
* Implemented methods in `BatteryEstimationService` to observe, learn, retrieve, and set charge overshoot calibration, including blending new observations and enforcing bounds. [[1]](diffhunk://#diff-63d83a42c37f697f23ce41ab734b54ee3b2792b41cb54b96ab41983f1ee53165R212-R290) [[2]](diffhunk://#diff-63d83a42c37f697f23ce41ab734b54ee3b2792b41cb54b96ab41983f1ee53165R470-R484) [[3]](diffhunk://#diff-09eb36fc47d150c8c1afbc58ec640d99718cfb5c17e85817b3394c88115112d0R13-R15)
* Integrated the learning process in `BatteryMonitorService` by detecting unplug events, capturing post-unplug battery drops, and passing observations to the estimation service. [[1]](diffhunk://#diff-86bd0109577712d173048d431a49036b794d848422ebb837ddca3d6414b634beR330-R331) [[2]](diffhunk://#diff-86bd0109577712d173048d431a49036b794d848422ebb837ddca3d6414b634beR344-R355) [[3]](diffhunk://#diff-86bd0109577712d173048d431a49036b794d848422ebb837ddca3d6414b634beR798-R800) [[4]](diffhunk://#diff-86bd0109577712d173048d431a49036b794d848422ebb837ddca3d6414b634beR820-R855)

**Applying Correction to Charge Estimates**

* Updated the charging estimation logic to apply the learned overshoot correction, scaling the adjustment by progress and confidence in the calibration.

**Persistence and Data Model Updates**

* Extended the storage interfaces and implementations to persist and load the learned charge overshoot calibration alongside other learned rates. [[1]](diffhunk://#diff-3c48369f8c6a6d8af356580ead67caa560bf697cf76642a2cbc661eb8372037bR17-R18) [[2]](diffhunk://#diff-99c8b63c18a04d572131db138e1b60dedc7e3a0c6a8eaf107d236641c8f4db8cR213-R235) [[3]](diffhunk://#diff-86bd0109577712d173048d431a49036b794d848422ebb837ddca3d6414b634beR1126-R1133) [[4]](diffhunk://#diff-86bd0109577712d173048d431a49036b794d848422ebb837ddca3d6414b634beR1213-R1231)

Other minor changes include logging improvements and minor code cleanups.